### PR TITLE
Fix Vercel build and auth request tests

### DIFF
--- a/src/__tests__/pages/login.test.jsx
+++ b/src/__tests__/pages/login.test.jsx
@@ -216,8 +216,10 @@ describe("Login Page", () => {
           expect.objectContaining({
             method: "POST",
             headers: {
+              "Cache-Control": "no-store, no-cache, must-revalidate",
               "Content-Type": "application/json",
             },
+            cache: "no-store",
           })
         );
       });

--- a/src/__tests__/services/oauthServices.test.ts
+++ b/src/__tests__/services/oauthServices.test.ts
@@ -47,12 +47,14 @@ describe('OAuth Services', () => {
         expect.objectContaining({
           method: 'POST',
           headers: {
+            'Cache-Control': 'no-store, no-cache, must-revalidate',
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             provider: 'google',
             access_token: 'google_oauth_token_123',
           }),
+          cache: 'no-store',
         })
       );
       

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useUserStore } from "@/store/user";
 import { LogoIcon, ProfileIcon, CartIcon, BurgerMenuIcon, CloseIcon, SearchOutlineIcon } from "@/svgs/icons";
-import { useState, useEffect, useRef } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import CartDropdown from "@/components/cart/CartDropdown";
 import { useCartSummary } from "@/hooks/useCartQuery";
 import { getTokens } from "@/lib/tokenManager";
@@ -17,7 +17,15 @@ import {
   navigationLinks,
 } from "./navigationLinks";
 
-export default function Navbar({ isPagination = true, hideMobilePaginationChrome = false, enableMobileInlineSearch = true }) {
+export default function Navbar(props) {
+  return (
+    <Suspense fallback={null}>
+      <NavbarContent {...props} />
+    </Suspense>
+  );
+}
+
+function NavbarContent({ isPagination = true, hideMobilePaginationChrome = false, enableMobileInlineSearch = true }) {
   const { userData } = useUserStore((state) => state);
   const [isCartOpen, setIsCartOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);


### PR DESCRIPTION
Summary:
- Wrap Navbar content in Suspense so Next.js can prerender pages that include Navbar while using useSearchParams.
- Update login and OAuth tests to expect no-cache fetch options added by the current auth request behavior.